### PR TITLE
Fix three code bugs

### DIFF
--- a/python/autoTest.py
+++ b/python/autoTest.py
@@ -2,6 +2,7 @@ import sys
 import os
 import osSystem
 import json
+import ast
 import requests
 import platform
 import subprocess
@@ -14,7 +15,10 @@ class AutoTestBench():
         self.origin_path = Path(sys.path[0] + '/../../')
         self.bin_path = self.origin_path.joinpath('linux-build/bin/Release/')
         self.system = platform.system()
-        self.JECKINS_INFO = eval(sys.argv[1])
+        try:
+            self.JECKINS_INFO = json.loads(sys.argv[1])
+        except Exception:
+            self.JECKINS_INFO = ast.literal_eval(sys.argv[1])
         
         self.webhook = self.JECKINS_INFO['WEBHOOK']
         self.commit_id = self.JECKINS_INFO['COMMIT_ID']


### PR DESCRIPTION
Replace unsafe `eval()` with safe JSON parsing and `ast.literal_eval()` in `python/autoTest.py` to prevent arbitrary code execution from command-line arguments.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3151f73-82bb-40ea-a7f6-98a20f90784c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c3151f73-82bb-40ea-a7f6-98a20f90784c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

